### PR TITLE
Make granular console IO recordable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules/
 dist/
 web/bundle.js
 console/bundle.js
-.tenant-interview-state.json
-tenant.schema.json
+.console-app-state.json
+console-app-state.schema.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,9 @@
     "json.schemas": [
         {
             "fileMatch": [
-                ".tenant-interview-state.json"
+                ".console-app-state.json"
             ],
-            "url": "./tenant.schema.json"
+            "url": "./console-app-state.schema.json"
         }
     ]
 }

--- a/console/main.ts
+++ b/console/main.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { addDays } from '../lib/util';
 import { Tenant } from '../lib/tenant';
 import { TenantInterview } from '../lib/tenant-interview';
-import { ReadlineInterviewIO } from '../lib/console/readline-io';
+import { TextInterviewIO } from '../lib/console/readline-io';
 import { FileSerializer } from '../lib/console/serializer';
 
 const SCRIPT = process.argv[1];
@@ -50,7 +50,7 @@ if (!module.parent) {
     now = addDays(now, parseInt(argv.days));
   }
 
-  const io = new ReadlineInterviewIO();
+  const io = new TextInterviewIO();
   const interview = new TenantInterview({ io, now });
   const serializer = new FileSerializer(STATE_FILE, INITIAL_STATE);
   interview.on('change', (_, tenant) => {

--- a/console/main.ts
+++ b/console/main.ts
@@ -10,8 +10,26 @@ import { RecordableInterviewIO, IoActionType } from '../lib/recordable-io';
 import { Recorder, RecordedAction } from '../lib/recorder';
 
 interface SerializableConsoleAppState {
+  /**
+   * Input that has been entered so far at a fairly high level,
+   * before a formal interview state change has occurred.
+   * 
+   * This can be used to replay the interview at a later time, to
+   * get back to the place the user was at when they were last
+   * using the app.
+   */
   recording: RecordedAction<IoActionType>[];
+  /**
+   * Input that has been entered at the most granular level, e.g.
+   * as part of a set of questions that would be answered in a
+   * single form on the web version of the interview.
+   * 
+   * This can be used to replay the interview at a later time, to
+   * get back to the place the user was at when they were last
+   * using the app.
+   */
   textRecording: RecordedAction<TextIOAction>[];
+  /** The state of the interview. */
   tenant: Tenant
 }
 

--- a/console/main.ts
+++ b/console/main.ts
@@ -35,7 +35,7 @@ interface SerializableConsoleAppState {
 
 const SCRIPT = process.argv[1];
 
-const STATE_FILE = '.tenant-interview-state.json';
+const STATE_FILE = '.console-app-state.json';
 
 const INITIAL_STATE: SerializableConsoleAppState = {
   recording: [],

--- a/lib/console/readline-io.ts
+++ b/lib/console/readline-io.ts
@@ -80,7 +80,7 @@ export class TextInterviewIO extends InterviewIO {
     this.isAsking = false;
 
     if (result instanceof ValidationError) {
-      this.textIO.writeLine(result.message);
+      await this.textIO.writeLine(result.message);
       return this.ask(question);
     }
 
@@ -98,12 +98,12 @@ export class TextInterviewIO extends InterviewIO {
   }
 
   async notify(text: string) {
-    this.textIO.writeLine(`\n${text}\n`);
+    await this.textIO.writeLine(`\n${text}\n`);
     await this.sleep(NOTIFY_DELAY_MS);
   }
 
   async setStatus(text: string) {
-    this.textIO.writeLine(text);
+    await this.textIO.writeLine(text);
   }
 
   close() {

--- a/lib/console/readline-io.ts
+++ b/lib/console/readline-io.ts
@@ -3,37 +3,62 @@ import * as readline from 'readline';
 import { InterviewIO, QuestionsFor } from '../interview-io';
 import { Question, ValidationError } from '../question';
 import { PhotoQuestion } from './photo';
-import { Photo, sleep } from '../util';
+import { Photo } from '../util';
+import { EventEmitter } from 'events';
 
 const NOTIFY_DELAY_MS = 3000;
 
-/** Standard interview i/o that uses readline/stdout. */
-export class ReadlineInterviewIO extends InterviewIO {
-  private rl: readline.ReadLine;
-  private output: NodeJS.WriteStream;
-  private isAsking: boolean;
+/**
+ * This represents a primarily text-based IO system.
+ */
+interface TextIO {
+  writeLine(text: string): Promise<void>;
+  question(query: string): Promise<string>;
+  close(): void;
+}
+
+/** Standard text i/o that uses readline/stdout. */
+export class ConsoleIO extends EventEmitter implements TextIO {
+  private readonly outputStream: NodeJS.WriteStream;
+  private readonly rl: readline.ReadLine;
 
   /**
    * @param rl A ReadLine object for the interview. If not provided, stdio will be used.
    * @param output The stream to which output will be written. Defaults to stdout.
    */
-  constructor(rl?: readline.ReadLine, output?: NodeJS.WriteStream) {
+  constructor(rl?: readline.ReadLine, outputStream?: NodeJS.WriteStream) {
     super();
-    this.isAsking = false;
-    this.output = output || process.stdout;
+    this.outputStream = outputStream || process.stdout;
     this.rl = rl || readline.createInterface({
       input: process.stdin,
-      output: this.output
+      output: this.outputStream
     });
   }
 
-  /** This is just a promisified wrapper around ReadLine.question(). */
-  private askRaw(query: string): Promise<string> {
+  async writeLine(text: string) {
+    this.outputStream.write(`${text}\n`);
+  }
+
+  question(query: string): Promise<string> {
     return new Promise((resolve, reject) => {
       this.rl.question(query, answer => {
         resolve(answer);
       });
     });
+  }
+
+  /** Close the underlying ReadLine object. */
+  close() {
+    this.rl.close();
+  }
+}
+
+/** Standard interview i/o that uses primarily text. */
+export class TextInterviewIO extends InterviewIO {
+  private isAsking: boolean = false;
+
+  constructor(private readonly textIO: TextIO = new ConsoleIO()) {
+    super();
   }
 
   async ask<T>(question: Question<T>): Promise<T> {
@@ -50,12 +75,12 @@ export class ReadlineInterviewIO extends InterviewIO {
     }
 
     this.isAsking = true;
-    const rawAnswer = await this.askRaw(`${text} `);
+    const rawAnswer = await this.textIO.question(`${text} `);
     const result = await question.processResponse(rawAnswer);
     this.isAsking = false;
 
     if (result instanceof ValidationError) {
-      this.output.write(`${result.message}\n`);
+      this.textIO.writeLine(result.message);
       return this.ask(question);
     }
 
@@ -73,17 +98,16 @@ export class ReadlineInterviewIO extends InterviewIO {
   }
 
   async notify(text: string) {
-    this.output.write(`\n${text}\n\n`);
-    await sleep(NOTIFY_DELAY_MS);
+    this.textIO.writeLine(`\n${text}\n`);
+    await this.sleep(NOTIFY_DELAY_MS);
   }
 
   async setStatus(text: string) {
-    this.output.write(`${text}\n`);
+    this.textIO.writeLine(text);
   }
 
-  /** Close the underlying ReadLine object. */
   close() {
-    this.rl.close();
+    this.textIO.close();
   }
 
   createPhotoQuestion(text: string): Question<Photo> {

--- a/lib/recordable-io.ts
+++ b/lib/recordable-io.ts
@@ -15,7 +15,7 @@ export type IoActionType = 'ask'|'askMany'|'notify'|'setStatus'|'sleep';
 export class RecordableInterviewIO extends InterviewIO {
   readonly recorder: Recorder<IoActionType>;
 
-  constructor(readonly delegate: InterviewIO, private readonly recording: RecordedAction<IoActionType>[] = []) {
+  constructor(readonly delegate: InterviewIO, recording: RecordedAction<IoActionType>[] = []) {
     super();
     this.recorder = new Recorder(recording);
   }

--- a/lib/recordable-io.ts
+++ b/lib/recordable-io.ts
@@ -1,10 +1,9 @@
 import { InterviewIO, QuestionsFor } from "./interview-io";
 import { Question, MultiChoiceAnswer } from "./question";
 import { Photo } from "./util";
+import { Recorder, RecordedAction } from "./recorder";
 
 export type IoActionType = 'ask'|'askMany'|'notify'|'setStatus'|'sleep';
-
-export type RecordedAction = [IoActionType, any];
 
 /**
  * This class can be used to record interview phases that are
@@ -14,58 +13,31 @@ export type RecordedAction = [IoActionType, any];
  * change after the full sequence is answered.
  */
 export class RecordableInterviewIO extends InterviewIO {
-  private readonly newRecording: RecordedAction[];
+  readonly recorder: Recorder<IoActionType>;
 
-  constructor(readonly delegate: InterviewIO, private readonly recording: RecordedAction[] = []) {
+  constructor(readonly delegate: InterviewIO, private readonly recording: RecordedAction<IoActionType>[] = []) {
     super();
-    this.recording = recording.slice();
-    this.newRecording = recording.slice();
-  }
-
-  getRecording(): RecordedAction[] {
-    return this.newRecording.slice();
-  }
-
-  resetRecording(): RecordedAction[] {
-    this.recording.splice(0);
-    this.newRecording.splice(0);
-    return this.getRecording();
-  }
-
-  private async playbackOrRecord<T>(type: IoActionType, record: () => Promise<T>): Promise<T> {
-    const result = this.recording.shift();
-    if (result !== undefined) {
-      const [actualType, value] = result;
-      if (actualType !== type) {
-        throw new Error(`Expected recorded action of type ${type} but got ${actualType}`);
-      }
-      return Promise.resolve(value);
-    } else {
-      this.emit('begin-recording-action', type);
-      const result = await record();
-      this.newRecording.push([type, result]);
-      return result;
-    }
+    this.recorder = new Recorder(recording);
   }
 
   ask<T>(question: Question<T>): Promise<T> {
-    return this.playbackOrRecord('ask', () => this.delegate.ask(question));
+    return this.recorder.playbackOrRecord('ask', () => this.delegate.ask(question));
   }
 
   askMany<T>(questions: QuestionsFor<T>): Promise<T> {
-    return this.playbackOrRecord('askMany', () => this.delegate.askMany(questions));
+    return this.recorder.playbackOrRecord('askMany', () => this.delegate.askMany(questions));
   }
 
   notify(text: string) {
-    return this.playbackOrRecord('notify', () => this.delegate.notify(text));
+    return this.recorder.playbackOrRecord('notify', () => this.delegate.notify(text));
   }
 
   setStatus(text: string) {
-    return this.playbackOrRecord('setStatus', () => this.delegate.setStatus(text));
+    return this.recorder.playbackOrRecord('setStatus', () => this.delegate.setStatus(text));
   }
 
   sleep(ms: number) {
-    return this.playbackOrRecord('sleep', () => this.delegate.sleep(ms));
+    return this.recorder.playbackOrRecord('sleep', () => this.delegate.sleep(ms));
   }
 
   createPhotoQuestion(text: string): Question<Photo> {
@@ -87,9 +59,4 @@ export class RecordableInterviewIO extends InterviewIO {
   createNonBlankQuestion(text: string): Question<string> {
     return this.delegate.createNonBlankQuestion(text);
   }
-}
-
-export interface RecordableInterviewIO {
-  on(event: 'begin-recording-action', listener: (type: IoActionType) => void): this;
-  emit(event: 'begin-recording-action', type: IoActionType): boolean;
 }

--- a/lib/recorder.ts
+++ b/lib/recorder.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from "events";
+
+export type RecordedAction<ActionType> = [ActionType, any];
+
+export class Recorder<ActionType> extends EventEmitter {
+  private readonly newRecording: RecordedAction<ActionType>[];
+
+  constructor(private readonly recording: RecordedAction<ActionType>[] = []) {
+    super();
+    this.recording = recording.slice();
+    this.newRecording = recording.slice();
+  }
+
+  getRecording(): RecordedAction<ActionType>[] {
+    return this.newRecording.slice();
+  }
+
+  resetRecording(): RecordedAction<ActionType>[] {
+    this.recording.splice(0);
+    this.newRecording.splice(0);
+    return this.getRecording();
+  }
+
+  async playbackOrRecord<T>(type: ActionType, record: () => Promise<T>): Promise<T> {
+    const result = this.recording.shift();
+    if (result !== undefined) {
+      const [actualType, value] = result;
+      if (actualType !== type) {
+        throw new Error(`Expected recorded action of type ${type} but got ${actualType}`);
+      }
+      return Promise.resolve(value);
+    } else {
+      this.emit('begin-recording-action', type);
+      const result = await record();
+      this.newRecording.push([type, result]);
+      return result;
+    }
+  }
+}
+
+export interface Recorder<ActionType> {
+  on(event: 'begin-recording-action', listener: (type: ActionType) => void): this;
+  emit(event: 'begin-recording-action', type: ActionType): boolean;
+}

--- a/lib/recorder.ts
+++ b/lib/recorder.ts
@@ -33,12 +33,15 @@ export class Recorder<ActionType> extends EventEmitter {
       this.emit('begin-recording-action', type);
       const result = await record();
       this.newRecording.push([type, result]);
+      this.emit('end-recording-action', type);
       return result;
     }
   }
 }
 
+type RecorderEvent = 'begin-recording-action'|'end-recording-action';
+
 export interface Recorder<ActionType> {
-  on(event: 'begin-recording-action', listener: (type: ActionType) => void): this;
-  emit(event: 'begin-recording-action', type: ActionType): boolean;
+  on(event: RecorderEvent, listener: (type: ActionType) => void): this;
+  emit(event: RecorderEvent, type: ActionType): boolean;
 }

--- a/lib/web/components/interview.tsx
+++ b/lib/web/components/interview.tsx
@@ -4,13 +4,14 @@ import { WebInterviewIO } from '../io';
 import { ModalBuilder } from '../modal';
 import { DateString } from '../../util';
 import { IOCancellationError } from '../../interview-io';
-import { RecordedAction, RecordableInterviewIO, IoActionType } from '../../recordable-io';
+import { RecordableInterviewIO, IoActionType } from '../../recordable-io';
 import { makeElement } from '../util';
 import { InterviewOptions, Interview, Command } from '../../interview';
+import { RecordedAction } from '../../recorder';
 
 export interface InterviewState<S> {
   s: S;
-  recording: RecordedAction[];
+  recording: RecordedAction<IoActionType>[];
 }
 
 export interface ICProps<S> {
@@ -56,7 +57,7 @@ export class InterviewComponent<S> extends React.Component<ICProps<S>, ICState<S
     this.io = new WebInterviewIO(this.innerDiv, new ModalBuilder(this.props.modalTemplate));
     this.io.on('title', this.handleTitleChange);
     this.recordableIo = new RecordableInterviewIO(this.io, this.props.initialState.recording);
-    this.recordableIo.on('begin-recording-action', this.handleBeginRecordingAction);
+    this.recordableIo.recorder.on('begin-recording-action', this.handleBeginRecordingAction);
     this.interview = new this.props.interviewClass({
       io: this.recordableIo,
       now: new Date(this.props.now)
@@ -118,7 +119,7 @@ export class InterviewComponent<S> extends React.Component<ICProps<S>, ICState<S
       if (!this.recordableIo) {
         throw new Error('Assertion failure!');
       }
-      const recording = this.recordableIo.getRecording();
+      const recording = this.recordableIo.recorder.getRecording();
       if (recording.length > this.state.recording.length) {
         this.setState({ recording });
       }
@@ -139,7 +140,7 @@ export class InterviewComponent<S> extends React.Component<ICProps<S>, ICState<S
     }
     this.setState({
       s,
-      recording: this.recordableIo.resetRecording()
+      recording: this.recordableIo.recorder.resetRecording()
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "schema": "typescript-json-schema tsconfig.json SerializableConsoleAppState > tenant.schema.json",
+    "schema": "typescript-json-schema tsconfig.json SerializableConsoleAppState > console-app-state.schema.json",
     "build": "webpack",
     "watch": "concurrently --kill-others \"http-server web -s\" \"webpack --watch\"",
     "deploy": "webpack && gh-pages -d web"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "schema": "typescript-json-schema tsconfig.json Tenant > tenant.schema.json",
+    "schema": "typescript-json-schema tsconfig.json SerializableConsoleAppState > tenant.schema.json",
     "build": "webpack",
     "watch": "concurrently --kill-others \"http-server web -s\" \"webpack --watch\"",
     "deploy": "webpack && gh-pages -d web"


### PR DESCRIPTION
Currently we have a `RecordableInterviewIO` class that records the responses of a user at the `InterviewIO` level so that they can be played-back later, which is what allows the Web UI to jump to any point in an interview, regardless of whether an actual state change has occurred. It's essentially a mechanism of saving the state of the stack in an interview, which is reliant on the assumption that the interview's state change methods are pure (in the functional sense) and only use `InterviewIO` for communicating with the outside world.

However, this is insufficient in the text-based world, where `InterviewIO.askMany()` is actually broken down into a series of questions asked of the user. In this case, if the user is in the middle of answering those questions and then leaves, we have no way of getting the interview back to the state they were at, because `InterviewIO.askMany()` hasn't yet returned (and therefore the `RecordableInterviewIO` has no way of recording any of the user's answers).

This fixes things by introducing a `RecordableTextIO` class, which records the individual answers a user provides while in an `InterviewIO` method.  It is kind of a slog to coordinate the saving of state between interview state changes, `RecordableInterviewIO` state changes, and `RecordableTextIO` state changes, though, which I am not a big fan of.  At some point we can figure out a better way to refactor this, but for now I want to get to the point where we actually have an interview accessible via SMS, which this is a prerequisite for.