### PR TITLE
Attempt to make questions structs instead of classes

### DIFF
--- a/lib/new-question.ts
+++ b/lib/new-question.ts
@@ -17,6 +17,8 @@ interface QResultMap {
   'text': string;
 }
 
+type QAnswerTypes = QResultMap[keyof QResultMap];
+
 type Q = YesNoQ | TextQ;
 
 type QsFor<T> = {
@@ -28,8 +30,8 @@ type QsFor<T> = {
 
 type QResult<T extends Q> = QResultMap[T['type']];
 
-interface MultiQuestions<T> {
-  [key: string]: boolean | string;
+type MultiQuestions<T> = {
+  [P in keyof T]: QAnswerTypes;
 }
 
 function askMany<S, T extends MultiQuestions<S>>(questions: QsFor<T>): T {

--- a/lib/new-question.ts
+++ b/lib/new-question.ts
@@ -1,0 +1,73 @@
+interface BaseQ {
+  type: string;
+  text: string;
+}
+
+interface YesNoQ extends BaseQ {
+  type: 'yesno';
+}
+
+interface TextQ extends BaseQ {
+  type: 'text';
+  canBeBlank?: true;
+}
+
+interface QResultMap {
+  'yesno': boolean;
+  'text': string;
+}
+
+type Q = YesNoQ | TextQ;
+
+type QsFor<T> = {
+  [P in keyof T]:
+    T[P] extends boolean ? YesNoQ :
+    T[P] extends string ? TextQ :
+    never;
+};
+
+type QResult<T extends Q> = QResultMap[T['type']];
+
+interface MultiQuestions<T> {
+  [key: string]: boolean | string;
+}
+
+function askMany<S, T extends MultiQuestions<S>>(questions: QsFor<T>): T {
+  const result = {} as T;
+
+  for (let key in questions) {
+    const question = questions[key];
+    const answer = ask(question);
+    result[key] = answer;
+  }
+
+  return result;
+}
+
+function ask<T extends Q>(question: T): QResult<T> {
+  // These all provide fake answers.
+  switch (question.type) {
+    case 'yesno':
+    return true;
+
+    case 'text':
+    return 'blah';
+  }
+}
+
+// Example code
+
+type BlargFluffle = {
+  thing: string;
+  meh: boolean;
+};
+
+let blargQuestions: QsFor<BlargFluffle> = {
+  thing: {type: 'text', text: 'what is thing?'},
+  meh: {type: 'yesno', text: 'are you meh?'},
+};
+
+let fluffle = askMany({
+  thing: {type: 'text', text: 'what is thing?'},
+  meh: {type: 'yesno', text: 'are you meh?'},
+} as QsFor<BlargFluffle>);


### PR DESCRIPTION
This is a failed attempt to make questions into structs rather than concrete classes. I ran into a bunch of annoying problems with type inference, largely stemming from the fact that it seems difficult to reconcile TypeScript generics (which aren't actually reflected/introspectable in runtime JS) with discriminated unions (which are introspectable in JS at runtime).
